### PR TITLE
Added Kaunas university of technology (ktu.edu)

### DIFF
--- a/lib/domains/edu/ktu.txt
+++ b/lib/domains/edu/ktu.txt
@@ -1,0 +1,1 @@
+Kaunas university of technology


### PR DESCRIPTION
Currently Kaunas university of technology has two addresses: ktu.edu and ktu.lt
